### PR TITLE
Fix #4 and incorrect options issue

### DIFF
--- a/nyanReporter.js
+++ b/nyanReporter.js
@@ -30,7 +30,7 @@ class NyanReporter {
    * 
    * @constructor
    */
-  constructor(options = {}) {
+  constructor(_, options = {}) {
     var nyanCatWidth = this.nyanCatWidth = 11;
     var width = window.width * 0.75 || 0;
 
@@ -111,7 +111,7 @@ class NyanReporter {
   /**
    * Draws the type of stat along with a color
    */
-  drawType(type, n) {
+  drawType(type, n = 0) {
     write(' ');
     write(color(type, n));
     write('\n');


### PR DESCRIPTION
As is mentioned in #4, `numPassedTests`(an other fields used by drawScoreboard) is not provided in `onRunStart` callback so its value is "undefined", We should give it a default value.

And, as is mentioned in jest's doc:
> Custom reporter modules must define a class that takes a GlobalConfig and reporter options as constructor arguments:
```js
// my-custom-reporter.js
class MyCustomReporter {
  constructor(globalConfig, options) {
    this._globalConfig = globalConfig;
    this._options = options;
  }

  onRunComplete(contexts, results) {
    console.log('Custom reporter output:');
    console.log('GlobalConfig: ', this._globalConfig);
    console.log('Options: ', this._options);
  }
}

module.exports = MyCustomReporter;
```

The first arg of constructor is `GlobalConfig` but we don't use it, so just skip it.